### PR TITLE
Add tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,17 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     builder (3.2.2)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    cliver (0.3.2)
     concurrent-ruby (1.0.2)
     erubis (2.7.0)
     globalid (0.3.6)
@@ -63,6 +72,10 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     pkg-config (1.1.7)
+    poltergeist (1.10.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -103,6 +116,11 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -110,6 +128,8 @@ PLATFORMS
 DEPENDENCIES
   better_frame!
   bundler (~> 1.10)
+  capybara (~> 2.7)
+  poltergeist (~> 1.10)
   rake (~> 11.0)
   sqlite3 (~> 1.3)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ class ExamplesController < ApplicationController
 end
 ```
 
+Side note: If you have `protect_from_forgery with: ...` in your controller you
+have to delete that because of the cross site origin requests.
+
 ### External (on your website which should embed the rails app)
 
 **NOTE: you need to have jQuery on the website which is embedding your rails

--- a/app/assets/javascripts/better_frame/better_frame.js
+++ b/app/assets/javascripts/better_frame/better_frame.js
@@ -23,7 +23,7 @@
     fill(event.currentTarget.href).then(storeURLInHistory);
   }
 
-  $(document).on("click", "#app-content a:not([target]='_blank')", handleLinks);
+  $(document).on("click", "#app-content a:not([target=\"_blank\"])", handleLinks);
 
   $(document).on("ajax:success", "#app-content form", function(e, data, status, xhr) {
     fillContent(data);

--- a/better_frame.gemspec
+++ b/better_frame.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.10"
   s.add_development_dependency "rake", "~> 11.0"
   s.add_development_dependency "sqlite3", "~> 1.3"
+  s.add_development_dependency "capybara", "~> 2.7"
+  s.add_development_dependency "poltergeist", "~> 1.10"
   s.add_dependency "rails", ">= 4.2", "< 5.1"
 end

--- a/lib/better_frame/better_frameable.rb
+++ b/lib/better_frame/better_frameable.rb
@@ -3,7 +3,6 @@ module BetterFrameable
 
   included do
     before_action :set_headers
-    skip_before_action :verify_authenticity_token
     layout 'better_frame/application'
   end
 

--- a/test/dummy/app/assets/javascripts/products.js
+++ b/test/dummy/app/assets/javascripts/products.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/test/dummy/app/assets/javascripts/products.js
+++ b/test/dummy/app/assets/javascripts/products.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,5 +1,2 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
 end

--- a/test/dummy/app/controllers/foreign_website_controller.rb
+++ b/test/dummy/app/controllers/foreign_website_controller.rb
@@ -1,0 +1,8 @@
+class ForeignWebsiteController < ApplicationController
+  def show
+    @current_url = "#{request.protocol}#{request.host_with_port}"
+    @rails_url = @current_url
+    @base_url = request.original_url
+    @include_url = @current_url + "/better_frame"
+  end
+end

--- a/test/dummy/app/controllers/products_controller.rb
+++ b/test/dummy/app/controllers/products_controller.rb
@@ -1,0 +1,59 @@
+class ProductsController < ApplicationController
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
+  include BetterFrameable
+
+  # GET /products
+  def index
+    @products = Product.all
+  end
+
+  # GET /products/1
+  def show
+  end
+
+  # GET /products/new
+  def new
+    @product = Product.new
+  end
+
+  # GET /products/1/edit
+  def edit
+  end
+
+  # POST /products
+  def create
+    @product = Product.new(product_params)
+
+    if @product.save
+      redirect_to @product, notice: 'Product was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /products/1
+  def update
+    if @product.update(product_params)
+      redirect_to @product, notice: 'Product was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /products/1
+  def destroy
+    @product.destroy
+    redirect_to products_url, notice: 'Product was successfully destroyed.'
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_product
+      @product = Product.find(params[:id])
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def product_params
+      params.require(:product).permit(:name, :price)
+    end
+end

--- a/test/dummy/app/models/product.rb
+++ b/test/dummy/app/models/product.rb
@@ -1,0 +1,2 @@
+class Product < ActiveRecord::Base
+end

--- a/test/dummy/app/views/foreign_website/show.html.erb
+++ b/test/dummy/app/views/foreign_website/show.html.erb
@@ -1,0 +1,3 @@
+<h1>ForeignWebsite</h1>
+<div id="app-content" data-baseurl="<%= @base_url %>" data-railsurl="<%= @rails_url %>"></div>
+<script src="<%= @include_url %>" type="text/javascript"></script>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <title>Dummy</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <script   src="https://code.jquery.com/jquery-1.8.0.min.js"   integrity="sha256-jFdOCgY5bfpwZLi0YODkqNXQdIxKpm6y5O/fy0baSzE="   crossorigin="anonymous"></script>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -2,10 +2,7 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <script   src="https://code.jquery.com/jquery-1.8.0.min.js"   integrity="sha256-jFdOCgY5bfpwZLi0YODkqNXQdIxKpm6y5O/fy0baSzE="   crossorigin="anonymous"></script>
-  <%= csrf_meta_tags %>
 </head>
 <body>
 

--- a/test/dummy/app/views/products/_form.html.erb
+++ b/test/dummy/app/views/products/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for(@product, remote: true) do |f| %>
+  <div class="field">
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
+  </div>
+  <div class="field">
+    <%= f.label :price %><br>
+    <%= f.text_field :price %>
+  </div>
+  <div class="actions">
+    <%= f.submit id: "submit-product" %>
+  </div>
+<% end %>

--- a/test/dummy/app/views/products/edit.html.erb
+++ b/test/dummy/app/views/products/edit.html.erb
@@ -1,0 +1,7 @@
+<p id="products-edit"></p>
+<h1>Editing Product</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @product %> |
+<%= link_to 'Back', products_url %>

--- a/test/dummy/app/views/products/index.html.erb
+++ b/test/dummy/app/views/products/index.html.erb
@@ -1,0 +1,29 @@
+<p id="products-index"></p>
+
+<h1>Listing Products</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Price</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @products.each do |product| %>
+      <tr>
+        <td><%= product.name %></td>
+        <td><%= product.price %></td>
+        <td><%= link_to 'Show', product %></td>
+        <td><%= link_to 'Edit', edit_product_path(product) %></td>
+        <td><%= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Product', new_product_url %>

--- a/test/dummy/app/views/products/new.html.erb
+++ b/test/dummy/app/views/products/new.html.erb
@@ -1,0 +1,6 @@
+<p id="products-new"></p>
+<h1>New Product</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', products_url %>

--- a/test/dummy/app/views/products/show.html.erb
+++ b/test/dummy/app/views/products/show.html.erb
@@ -1,0 +1,14 @@
+<p id="products-show"></p>
+
+<p id="name">
+  <strong>Name:</strong>
+  <%= @product.name %>
+</p>
+
+<p id="price">
+  <strong>Price:</strong>
+  <%= @product.price %>
+</p>
+
+<%= link_to 'Edit', edit_product_url(@product) %> |
+<%= link_to 'Back', products_url %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
   mount BetterFrame::Engine => "/better_frame"
+
+  root "products#index"
+  get 'foreign_website' => 'foreign_website#show'
+  resources :products
 end

--- a/test/dummy/db/migrate/20160714124731_create_products.rb
+++ b/test/dummy/db/migrate/20160714124731_create_products.rb
@@ -1,0 +1,10 @@
+class CreateProducts < ActiveRecord::Migration
+  def change
+    create_table :products do |t|
+      t.string :name
+      t.float :price
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,23 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20160714124731) do
+
+  create_table "products", force: :cascade do |t|
+    t.string   "name"
+    t.float    "price"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  price: 1.5
+
+two:
+  name: MyString
+  price: 1.5

--- a/test/integration/include_test.rb
+++ b/test/integration/include_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class IncludeTest < ActionDispatch::IntegrationTest
+  test "include & navigate site with better_frame" do
+    visit '/foreign_website'
+    wait_for_page_load("products#index")
+
+    assert_equal '/', find("#rails-path")["data-path"]
+
+    click_on "New Product"
+    wait_for_page_load("products#new")
+
+    history(:back)
+    wait_for_page_load("products#index")
+
+    assert_equal 2, all("table tbody tr").count
+
+    history(:forward)
+    wait_for_page_load("products#new")
+
+    assert_equal '/products/new', find("#rails-path")["data-path"]
+
+    fill_in "Name", with: "test"
+    fill_in "Price", with: "120.30"
+    find("#submit-product").click
+
+    wait_for_page_load("products#show")
+
+    assert_equal "Name: test", find("#name").text
+    assert_equal "Price: 120.3", find("#price").text
+
+    click_on "Back"
+    wait_for_page_load("products#index")
+
+    assert_equal 3, all("table tbody tr").count
+  end
+
+  def wait_for_page_load(id)
+    converted_id_selector = "#" + id.gsub("#", "-")
+    find(converted_id_selector)
+  end
+
+  def history(whereto)
+    page.execute_script "window.history.#{whereto}()"
+  end
+end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
 require "rails/test_help"
+require 'capybara/rails'
+require 'capybara/poltergeist'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
@@ -18,4 +20,19 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
   ActiveSupport::TestCase.fixtures :all
+end
+
+class ActionDispatch::IntegrationTest
+  # Make the Capybara DSL available in all integration tests
+  include Capybara::DSL
+
+  def setup
+    Capybara.default_driver = :poltergeist
+  end
+
+  # Reset sessions and driver between tests
+  # Use super wherever this method is redefined in your individual test classes
+  def teardown
+    Capybara.reset_sessions!
+  end
 end


### PR DESCRIPTION
why remove skip_before_action?
because if a controller includes the BetterFrameable Concern,
there's a chance that in there is no `protect_from_forgery` in the controller.
If that happens, the BetterFrameable module will try to skip that, but it will raise an exception because it hasn't been defined.